### PR TITLE
feat: use `enabled` flag and add null handling to outputs

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -5,7 +5,9 @@ locals {
 
 module "kafka" {
   source  = "cloudposse/msk-apache-kafka-cluster/aws"
-  version = "2.3.0"
+  version = "2.4.0"
+
+  enabled = local.enabled
 
   # VPC and subnets
   vpc_id     = local.vpc_outputs.vpc_id

--- a/src/outputs.tf
+++ b/src/outputs.tf
@@ -1,99 +1,99 @@
 output "cluster_name" {
-  value       = module.kafka.cluster_name
+  value       = try(module.kafka.cluster_name, null)
   description = "The cluster name of the MSK cluster"
 }
 
 output "cluster_arn" {
-  value       = module.kafka.cluster_arn
+  value       = try(module.kafka.cluster_arn, null)
   description = "Amazon Resource Name (ARN) of the MSK cluster"
 }
 
 output "storage_mode" {
-  value       = module.kafka.storage_mode
+  value       = try(module.kafka.storage_mode, null)
   description = "Storage mode for supported storage tiers"
 }
 
 output "bootstrap_brokers" {
-  value       = module.kafka.bootstrap_brokers
+  value       = try(module.kafka.bootstrap_brokers, null)
   description = "Comma separated list of one or more hostname:port pairs of Kafka brokers suitable to bootstrap connectivity to the Kafka cluster"
 }
 
 output "bootstrap_brokers_tls" {
-  value       = module.kafka.bootstrap_brokers_tls
+  value       = try(module.kafka.bootstrap_brokers_tls, null)
   description = "Comma separated list of one or more DNS names (or IP addresses) and TLS port pairs for access to the Kafka cluster using TLS"
 }
 
 output "bootstrap_brokers_public_tls" {
-  value       = module.kafka.bootstrap_brokers_public_tls
+  value       = try(module.kafka.bootstrap_brokers_public_tls, null)
   description = "Comma separated list of one or more DNS names (or IP addresses) and TLS port pairs for public access to the Kafka cluster using TLS"
 }
 
 output "bootstrap_brokers_sasl_scram" {
-  value       = module.kafka.bootstrap_brokers_sasl_scram
+  value       = try(module.kafka.bootstrap_brokers_sasl_scram, null)
   description = "Comma separated list of one or more DNS names (or IP addresses) and SASL SCRAM port pairs for access to the Kafka cluster using SASL/SCRAM"
 }
 
 output "bootstrap_brokers_public_sasl_scram" {
-  value       = module.kafka.bootstrap_brokers_public_sasl_scram
+  value       = try(module.kafka.bootstrap_brokers_public_sasl_scram, null)
   description = "Comma separated list of one or more DNS names (or IP addresses) and SASL SCRAM port pairs for public access to the Kafka cluster using SASL/SCRAM"
 }
 
 output "bootstrap_brokers_sasl_iam" {
-  value       = module.kafka.bootstrap_brokers_sasl_iam
+  value       = try(module.kafka.bootstrap_brokers_sasl_iam, null)
   description = "Comma separated list of one or more DNS names (or IP addresses) and SASL IAM port pairs for access to the Kafka cluster using SASL/IAM"
 }
 
 output "bootstrap_brokers_public_sasl_iam" {
-  value       = module.kafka.bootstrap_brokers_public_sasl_iam
+  value       = try(module.kafka.bootstrap_brokers_public_sasl_iam, null)
   description = "Comma separated list of one or more DNS names (or IP addresses) and SASL IAM port pairs for public access to the Kafka cluster using SASL/IAM"
 }
 
 output "zookeeper_connect_string" {
-  value       = module.kafka.zookeeper_connect_string
+  value       = try(module.kafka.zookeeper_connect_string, null)
   description = "Comma separated list of one or more hostname:port pairs to connect to the Apache Zookeeper cluster"
 }
 
 output "zookeeper_connect_string_tls" {
-  value       = module.kafka.zookeeper_connect_string_tls
+  value       = try(module.kafka.zookeeper_connect_string_tls, null)
   description = "Comma separated list of one or more hostname:port pairs to connect to the Apache Zookeeper cluster via TLS"
 }
 
 output "broker_endpoints" {
-  value       = module.kafka.broker_endpoints
+  value       = try(module.kafka.broker_endpoints, null)
   description = "List of broker endpoints"
 }
 
 output "current_version" {
-  value       = module.kafka.current_version
+  value       = try(module.kafka.current_version, null)
   description = "Current version of the MSK Cluster"
 }
 
 output "config_arn" {
-  value       = module.kafka.config_arn
+  value       = try(module.kafka.config_arn, null)
   description = "Amazon Resource Name (ARN) of the MSK configuration"
 }
 
 output "latest_revision" {
-  value       = module.kafka.latest_revision
+  value       = try(module.kafka.latest_revision, null)
   description = "Latest revision of the MSK configuration"
 }
 
 output "hostnames" {
-  value       = module.kafka.hostnames
+  value       = try(module.kafka.hostnames, null)
   description = "List of MSK Cluster broker DNS hostnames"
 }
 
 output "security_group_id" {
-  value       = module.kafka.security_group_id
+  value       = try(module.kafka.security_group_id, null)
   description = "The ID of the created security group"
 }
 
 output "security_group_arn" {
-  value       = module.kafka.security_group_arn
+  value       = try(module.kafka.security_group_arn, null)
   description = "The ARN of the created security group"
 }
 
 output "security_group_name" {
-  value       = module.kafka.security_group_name
+  value       = try(module.kafka.security_group_name, null)
   description = "The name of the created security group"
 }


### PR DESCRIPTION
## what and why

- Add `try()` statements because none of the outputs have conditional checks or null handling. If any of the `module.kafka` attributes resolve to null or empty strings (especially connection strings like bootstrap_brokers), downstream consumers of these outputs could fail in unexpected ways
- Use `local.enabled` for resource creation and deletion in the module

## references

- [Try Outputs](https://stackoverflow.com/questions/74352603/conditional-outputs-on-data-sources-in-terraform)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated Kafka integration to use the latest supported version.
  - Added an option to enable or disable the Kafka module based on configuration.

- **Bug Fixes**
  - Improved reliability of output values by ensuring they return null instead of causing errors when Kafka attributes are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->